### PR TITLE
Reset command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ["n", "tx", "new_tx", "start_tx"]
     );
     command!(
+        cmd_reset,
+        "-- reset, removing breakpoints and other state",
+        ["reset"]
+    );
+    command!(
         cmd_continue,
         "-- run until next breakpoint or termination",
         ["c", "continue"]
@@ -96,6 +101,17 @@ async fn cmd_start_tx(state: &mut State, mut args: Vec<String>) -> Result<(), Bo
     let tx: Transaction = serde_json::from_slice(&tx_json).unwrap();
     let status = state.client.start_tx(&state.session_id, &tx).await?;
     println!("{:?}", status); // TODO: pretty-print
+
+    Ok(())
+}
+
+async fn cmd_reset(state: &mut State, mut args: Vec<String>) -> Result<(), Box<dyn Error>> {
+    args.remove(0);
+    if !args.is_empty() {
+        return Err(Box::new(ArgError::TooMany));
+    }
+
+    let _ = state.client.reset(&state.session_id).await?;
 
     Ok(())
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -47,6 +47,9 @@ fn test_cli() {
     cmd.exp_regex(r">> ").unwrap();
     cmd.send_line("continue").unwrap();
     cmd.exp_regex(r"breakpoint: None").unwrap();
+    cmd.send_line("reset").unwrap();
+    cmd.send_line("start_tx examples/example_tx.json").unwrap();
+    cmd.exp_regex(r"breakpoint: None").unwrap();
     cmd.send_line(r"exit").unwrap();
 
     fuel_core.kill().expect("Couldn't kill fuel-core");


### PR DESCRIPTION
Resets the underlying VM to initial state, so that you don't have to restart the whole debugger to get a new session. This is already supported by fuel-core debugger API, but the CLI command was not added yet.